### PR TITLE
[FEAT] ViewController & View에서 preview를 확인하는 기능

### DIFF
--- a/Hatnya.xcodeproj/project.pbxproj
+++ b/Hatnya.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		A28DEFA528855325004014DE /* ImageLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28DEFA428855325004014DE /* ImageLiteral.swift */; };
 		A28DEFA828855354004014DE /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28DEFA728855354004014DE /* UIColor+Extension.swift */; };
 		AEC29DA528858DE700DA24B8 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = AEC29DA428858DE700DA24B8 /* .swiftlint.yml */; };
+		AEC29DA72886E63500DA24B8 /* ViewController+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC29DA62886E63500DA24B8 /* ViewController+Preview.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -44,6 +45,7 @@
 		A28DEFA428855325004014DE /* ImageLiteral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLiteral.swift; sourceTree = "<group>"; };
 		A28DEFA728855354004014DE /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
 		AEC29DA428858DE700DA24B8 /* .swiftlint.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		AEC29DA62886E63500DA24B8 /* ViewController+Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Preview.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -205,6 +207,7 @@
 			isa = PBXGroup;
 			children = (
 				A28DEFA728855354004014DE /* UIColor+Extension.swift */,
+				AEC29DA62886E63500DA24B8 /* ViewController+Preview.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -306,6 +309,7 @@
 				A28DEF7728854EEF004014DE /* ViewController.swift in Sources */,
 				A28DEF9B28855248004014DE /* WriteNicknameViewController.swift in Sources */,
 				A28DEFA828855354004014DE /* UIColor+Extension.swift in Sources */,
+				AEC29DA72886E63500DA24B8 /* ViewController+Preview.swift in Sources */,
 				A28DEFA528855325004014DE /* ImageLiteral.swift in Sources */,
 				A28DEF7328854EEF004014DE /* AppDelegate.swift in Sources */,
 				A28DEF9F28855299004014DE /* StudyListViewController.swift in Sources */,

--- a/Hatnya/Global/Extension/ViewController+Preview.swift
+++ b/Hatnya/Global/Extension/ViewController+Preview.swift
@@ -1,0 +1,103 @@
+//
+//  ViewController+Preview.swift
+//  Hatnya
+//
+//  Created by 리아 on 2022/07/19.
+//
+
+import SwiftUI
+import UIKit
+
+extension UIViewController {
+    
+    private struct Preview: UIViewControllerRepresentable {
+
+        let viewController: UIViewController
+        
+        func makeUIViewController(context: Context) -> some UIViewController {
+            return viewController
+        }
+        
+        func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {
+        }
+
+    }
+    
+    /// UIViewController의 preview를 제공해주는 메서드
+    ///
+    /// 아래의 코드를 통해 UIViewController의 preview를 확인해볼 수 있다
+    ///
+    /// ```swift
+    /// import SwiftUI
+    ///
+    /// struct SomeViewControllerPreview: PreviewProvider {
+    ///     static var previews: some View {
+    ///         SomeViewController().toPreview()
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// 스토리보드로 ViewController를 구현한 경우에는 다음과 같이 사용할 수 있다
+    /// ```swift
+    /// struct SomeViewControllerPreview: PreviewProvider {
+    ///     static var previews: some View {
+    ///         UIStoryboard(name: "Main", bundle: nil).instantiateViewController(identifier: "SomeViewController")
+    ///         .toPreview()
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// 다크 모드나 디바이스 변경 등의 동작을 지원한다
+    /// ```swift
+    /// struct SomeViewControllerPreview: PreviewProvider {
+    ///     static var previews: some View {
+    ///         SomeViewController()
+    ///             .toPreview()
+    ///             .previewDevice("iPhone 13 Pro")
+    ///             .preferredColorScheme(.dark)
+    ///     }
+    /// }
+    /// ```
+
+    func toPreview() -> some View {
+        Preview(viewController: self)
+    }
+    
+}
+
+extension UIView {
+
+    private struct Preview: UIViewRepresentable {
+
+        let view: UIView
+
+        func makeUIView(context: Context) -> some UIView {
+            return view
+        }
+
+        func updateUIView(_ uiView: UIViewType, context: Context) {
+        }
+
+    }
+
+    /// UIView의 preview를 제공해주는 메서드
+    ///
+    /// 아래의 코드를 통해 UIView의 preview를 확인해볼 수 있다
+    ///
+    /// ```swift
+    /// import SwiftUI
+    ///
+    /// struct SomeViewPreview: PreviewProvider {
+    ///     static var previews: some View {
+    ///         SomeView().toPreview()
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// UIView를 상속받는 CollectionViewCell 등에도 적용 가능하다
+
+    func toPreview() -> some View {
+        Preview(view: self)
+    }
+
+}


### PR DESCRIPTION
## 작업내용
- [x] 뷰컨트롤러와 뷰를 상속하는 모든 객체에 프리뷰 기능 추가

<img width="1244" alt="image" src="https://user-images.githubusercontent.com/73650994/179764932-161bd9dc-a707-4f73-9c2f-c85640adb949.png">

## 리뷰포인트
- DocC를 이용하여 프리뷰 기능 사용 방법을 추가했습니다.
<img width="676" alt="image" src="https://user-images.githubusercontent.com/73650994/179765251-0a880edc-26ab-4650-a8e0-d4463c64bec6.png">

## 다음으로 진행될 작업
 - 숙제 리스트 테이블뷰

## 참고한 코드 출처
- [포마님의 블로그 - UIKit에서 SwiftUI Preview 사용해보기](https://fomaios.tistory.com/entry/iOS-UIKit에서-SwiftUI-Preview-사용해보기)
- [DocC 공식 문서 및 예제 코드](https://www.swift.org/documentation/docc)