### PR TITLE
[FEAT] StudyRoom - homework list

### DIFF
--- a/Hatnya.xcodeproj/project.pbxproj
+++ b/Hatnya.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		AEC29DA72886E63500DA24B8 /* ViewController+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC29DA62886E63500DA24B8 /* ViewController+Preview.swift */; };
 		AED2E1B52887B4C700B32FF7 /* HomeworkListTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED2E1B42887B4C700B32FF7 /* HomeworkListTitleView.swift */; };
 		AED2E1B72887B4DF00B32FF7 /* HomeworkListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED2E1B62887B4DF00B32FF7 /* HomeworkListCell.swift */; };
+		AED2E1B928880EDC00B32FF7 /* Homework.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED2E1B828880EDC00B32FF7 /* Homework.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -54,6 +55,7 @@
 		AEC29DA62886E63500DA24B8 /* ViewController+Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Preview.swift"; sourceTree = "<group>"; };
 		AED2E1B42887B4C700B32FF7 /* HomeworkListTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeworkListTitleView.swift; sourceTree = "<group>"; };
 		AED2E1B62887B4DF00B32FF7 /* HomeworkListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeworkListCell.swift; sourceTree = "<group>"; };
+		AED2E1B828880EDC00B32FF7 /* Homework.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Homework.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -116,6 +118,7 @@
 			isa = PBXGroup;
 			children = (
 				A28DEFA0288552CC004014DE /* StudyGroup.swift */,
+				AED2E1B828880EDC00B32FF7 /* Homework.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -336,6 +339,7 @@
 				A28DEFA528855325004014DE /* ImageLiteral.swift in Sources */,
 				A28DEF7328854EEF004014DE /* AppDelegate.swift in Sources */,
 				A28DEF9F28855299004014DE /* StudyListViewController.swift in Sources */,
+				AED2E1B928880EDC00B32FF7 /* Homework.swift in Sources */,
 				A28DEFA1288552CC004014DE /* StudyGroup.swift in Sources */,
 				AED2E1B52887B4C700B32FF7 /* HomeworkListTitleView.swift in Sources */,
 				A28DEF9728855228004014DE /* EditTaskViewController.swift in Sources */,

--- a/Hatnya.xcodeproj/project.pbxproj
+++ b/Hatnya.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		AED2E1B72887B4DF00B32FF7 /* HomeworkListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED2E1B62887B4DF00B32FF7 /* HomeworkListCell.swift */; };
 		AED2E1B928880EDC00B32FF7 /* Homework.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED2E1B828880EDC00B32FF7 /* Homework.swift */; };
 		AED2E1BC2888DE6E00B32FF7 /* TagColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED2E1BB2888DE6E00B32FF7 /* TagColor.swift */; };
+		AED2E1BE2888DF2D00B32FF7 /* UILabel+StrikeThrough.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED2E1BD2888DF2D00B32FF7 /* UILabel+StrikeThrough.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -58,6 +59,7 @@
 		AED2E1B62887B4DF00B32FF7 /* HomeworkListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeworkListCell.swift; sourceTree = "<group>"; };
 		AED2E1B828880EDC00B32FF7 /* Homework.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Homework.swift; sourceTree = "<group>"; };
 		AED2E1BB2888DE6E00B32FF7 /* TagColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagColor.swift; sourceTree = "<group>"; };
+		AED2E1BD2888DF2D00B32FF7 /* UILabel+StrikeThrough.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+StrikeThrough.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -233,6 +235,7 @@
 			isa = PBXGroup;
 			children = (
 				A28DEFA728855354004014DE /* UIColor+Extension.swift */,
+				AED2E1BD2888DF2D00B32FF7 /* UILabel+StrikeThrough.swift */,
 				AEC29DA62886E63500DA24B8 /* ViewController+Preview.swift */,
 			);
 			path = Extension;
@@ -345,6 +348,7 @@
 				AED2E1B72887B4DF00B32FF7 /* HomeworkListCell.swift in Sources */,
 				A28DEF7728854EEF004014DE /* ViewController.swift in Sources */,
 				A28DEF9B28855248004014DE /* WriteNicknameViewController.swift in Sources */,
+				AED2E1BE2888DF2D00B32FF7 /* UILabel+StrikeThrough.swift in Sources */,
 				A28DEFA828855354004014DE /* UIColor+Extension.swift in Sources */,
 				AEC29DA72886E63500DA24B8 /* ViewController+Preview.swift in Sources */,
 				A28DEFA528855325004014DE /* ImageLiteral.swift in Sources */,

--- a/Hatnya.xcodeproj/project.pbxproj
+++ b/Hatnya.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		A28DEFA828855354004014DE /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28DEFA728855354004014DE /* UIColor+Extension.swift */; };
 		AEC29DA528858DE700DA24B8 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = AEC29DA428858DE700DA24B8 /* .swiftlint.yml */; };
 		AEC29DA72886E63500DA24B8 /* ViewController+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC29DA62886E63500DA24B8 /* ViewController+Preview.swift */; };
+		AED2E1B52887B4C700B32FF7 /* HomeworkListTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED2E1B42887B4C700B32FF7 /* HomeworkListTitleView.swift */; };
+		AED2E1B72887B4DF00B32FF7 /* HomeworkListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED2E1B62887B4DF00B32FF7 /* HomeworkListCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -50,6 +52,8 @@
 		A28DEFA728855354004014DE /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
 		AEC29DA428858DE700DA24B8 /* .swiftlint.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		AEC29DA62886E63500DA24B8 /* ViewController+Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Preview.swift"; sourceTree = "<group>"; };
+		AED2E1B42887B4C700B32FF7 /* HomeworkListTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeworkListTitleView.swift; sourceTree = "<group>"; };
+		AED2E1B62887B4DF00B32FF7 /* HomeworkListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeworkListCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -67,6 +71,8 @@
 			isa = PBXGroup;
 			children = (
 				39F3F8E52886778900256D56 /* StudyChartView.swift */,
+				AED2E1B62887B4DF00B32FF7 /* HomeworkListCell.swift */,
+				AED2E1B42887B4C700B32FF7 /* HomeworkListTitleView.swift */,
 			);
 			path = UIComponent;
 			sourceTree = "<group>";
@@ -322,6 +328,7 @@
 				39F3F8E62886778900256D56 /* StudyChartView.swift in Sources */,
 				3982366D2886EF0400F6B004 /* ColorLiteral.swift in Sources */,
 				A28DEF9D28855285004014DE /* JoinStudyViewController.swift in Sources */,
+				AED2E1B72887B4DF00B32FF7 /* HomeworkListCell.swift in Sources */,
 				A28DEF7728854EEF004014DE /* ViewController.swift in Sources */,
 				A28DEF9B28855248004014DE /* WriteNicknameViewController.swift in Sources */,
 				A28DEFA828855354004014DE /* UIColor+Extension.swift in Sources */,
@@ -330,6 +337,7 @@
 				A28DEF7328854EEF004014DE /* AppDelegate.swift in Sources */,
 				A28DEF9F28855299004014DE /* StudyListViewController.swift in Sources */,
 				A28DEFA1288552CC004014DE /* StudyGroup.swift in Sources */,
+				AED2E1B52887B4C700B32FF7 /* HomeworkListTitleView.swift in Sources */,
 				A28DEF9728855228004014DE /* EditTaskViewController.swift in Sources */,
 				A28DEF9528855209004014DE /* CreateStudyViewController.swift in Sources */,
 				A28DEF7528854EEF004014DE /* SceneDelegate.swift in Sources */,

--- a/Hatnya.xcodeproj/project.pbxproj
+++ b/Hatnya.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		AED2E1B52887B4C700B32FF7 /* HomeworkListTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED2E1B42887B4C700B32FF7 /* HomeworkListTitleView.swift */; };
 		AED2E1B72887B4DF00B32FF7 /* HomeworkListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED2E1B62887B4DF00B32FF7 /* HomeworkListCell.swift */; };
 		AED2E1B928880EDC00B32FF7 /* Homework.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED2E1B828880EDC00B32FF7 /* Homework.swift */; };
+		AED2E1BC2888DE6E00B32FF7 /* TagColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED2E1BB2888DE6E00B32FF7 /* TagColor.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -56,6 +57,7 @@
 		AED2E1B42887B4C700B32FF7 /* HomeworkListTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeworkListTitleView.swift; sourceTree = "<group>"; };
 		AED2E1B62887B4DF00B32FF7 /* HomeworkListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeworkListCell.swift; sourceTree = "<group>"; };
 		AED2E1B828880EDC00B32FF7 /* Homework.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Homework.swift; sourceTree = "<group>"; };
+		AED2E1BB2888DE6E00B32FF7 /* TagColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagColor.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -140,6 +142,7 @@
 		A28DEF8A288550C9004014DE /* Global */ = {
 			isa = PBXGroup;
 			children = (
+				AED2E1BA2888DE5E00B32FF7 /* Utility */,
 				A28DEFA62885533D004014DE /* Extension */,
 				A28DEFA32885530C004014DE /* Literal */,
 				A28DEF8D28855112004014DE /* Resource */,
@@ -233,6 +236,14 @@
 				AEC29DA62886E63500DA24B8 /* ViewController+Preview.swift */,
 			);
 			path = Extension;
+			sourceTree = "<group>";
+		};
+		AED2E1BA2888DE5E00B32FF7 /* Utility */ = {
+			isa = PBXGroup;
+			children = (
+				AED2E1BB2888DE6E00B32FF7 /* TagColor.swift */,
+			);
+			path = Utility;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -341,6 +352,7 @@
 				A28DEF9F28855299004014DE /* StudyListViewController.swift in Sources */,
 				AED2E1B928880EDC00B32FF7 /* Homework.swift in Sources */,
 				A28DEFA1288552CC004014DE /* StudyGroup.swift in Sources */,
+				AED2E1BC2888DE6E00B32FF7 /* TagColor.swift in Sources */,
 				AED2E1B52887B4C700B32FF7 /* HomeworkListTitleView.swift in Sources */,
 				A28DEF9728855228004014DE /* EditTaskViewController.swift in Sources */,
 				A28DEF9528855209004014DE /* CreateStudyViewController.swift in Sources */,

--- a/Hatnya/Global/Extension/UIColor+Extension.swift
+++ b/Hatnya/Global/Extension/UIColor+Extension.swift
@@ -14,4 +14,20 @@ extension UIColor {
     static var grey001: UIColor {
         return UIColor(hex: "#979797")
     }
+    static var tagPink: UIColor {
+        return UIColor(hex: "#FDC3B1")
+    }
+    static var tagYellow: UIColor {
+        return UIColor(hex: "#FFE897")
+    }
+    static var tagGreen: UIColor {
+        return UIColor(hex: "#D4EBCC")
+    }
+    static var tagLightBlue: UIColor {
+        return UIColor(hex: "#C9E8EF")
+    }
+    static var tagPurple: UIColor {
+        return UIColor(hex: "#D3C9EF")
+    }
+
 }

--- a/Hatnya/Global/Extension/UILabel+StrikeThrough.swift
+++ b/Hatnya/Global/Extension/UILabel+StrikeThrough.swift
@@ -1,0 +1,31 @@
+//
+//  UILabel+StrikeThrough.swift
+//  Hatnya
+//
+//  Created by 리아 on 2022/07/21.
+//
+
+import UIKit
+
+extension UILabel {
+    
+    func strikeThrough(_ isStrikeThrough: Bool) {
+        if isStrikeThrough {
+            if let text = self.text {
+                let attributedText = NSMutableAttributedString(string: text)
+                attributedText.addAttribute(
+                    .strikethroughStyle,
+                    value: NSUnderlineStyle.single.rawValue,
+                    range: NSRange(location: 0, length: attributedText.length))
+                self.attributedText = attributedText
+            }
+        } else {
+            if let attributedText = self.attributedText {
+                let text = attributedText.string
+                self.attributedText = nil
+                self.text = text
+            }
+        }
+    }
+    
+}

--- a/Hatnya/Global/Utility/TagColor.swift
+++ b/Hatnya/Global/Utility/TagColor.swift
@@ -1,0 +1,38 @@
+//
+//  TagColor.swift
+//  Hatnya
+//
+//  Created by 리아 on 2022/07/21.
+//
+
+import UIKit
+
+enum TagColor: Int, CaseIterable {
+    case pink
+    case yellow
+    case green
+    case lightBlue
+    case purple
+    
+    static func color(_ tagColor: TagColor) -> UIColor {
+        switch tagColor {
+        case .pink:
+            return .tagPink
+        case .yellow:
+            return .tagYellow
+        case .green:
+            return .tagGreen
+        case .lightBlue:
+            return .tagLightBlue
+        case .purple:
+            return .tagPurple
+        }
+    }
+    
+    static func order(index: Int) -> UIColor {
+        let colorNum = index % Self.allCases.count
+        let orderColor = TagColor(rawValue: colorNum) ?? .pink
+        return Self.color(orderColor)
+    }
+
+}

--- a/Hatnya/Network/Models/Homework.swift
+++ b/Hatnya/Network/Models/Homework.swift
@@ -1,0 +1,22 @@
+//
+//  Homework.swift
+//  Hatnya
+//
+//  Created by 리아 on 2022/07/20.
+//
+
+import Foundation
+
+struct Homework: Hashable {
+    let id = UUID()
+    let name: String
+    let due: Date
+    let isCompleted: Bool
+}
+
+struct HomeworkMockData {
+    static let list = [hw1, hw2, hw3]
+    static let hw1 = Homework(name: "알고리즘 1091번", due: Date(), isCompleted: true)
+    static let hw2 = Homework(name: "알고리즘 3434번", due: Date(), isCompleted: false)
+    static let hw3 = Homework(name: "DP 개념 공부", due: Date(), isCompleted: false)
+}

--- a/Hatnya/Network/Models/Homework.swift
+++ b/Hatnya/Network/Models/Homework.swift
@@ -16,7 +16,16 @@ struct Homework: Hashable {
 
 struct HomeworkMockData {
     static let list = [hw1, hw2, hw3]
+    static let longList = [hw1, hw2, hw3, hw4, hw5, hw6, hw7, hw8, hw9, hw10]
+    
     static let hw1 = Homework(name: "알고리즘 1091번", due: Date(), isCompleted: true)
     static let hw2 = Homework(name: "알고리즘 3434번", due: Date(), isCompleted: false)
     static let hw3 = Homework(name: "DP 개념 공부", due: Date(), isCompleted: false)
+    static let hw4 = Homework(name: "BFS 개념 공부", due: Date(), isCompleted: false)
+    static let hw5 = Homework(name: "DFS 개념 공부", due: Date(), isCompleted: false)
+    static let hw6 = Homework(name: "NP 개념 공부", due: Date(), isCompleted: false)
+    static let hw7 = Homework(name: "Greedy 개념 공부", due: Date(), isCompleted: false)
+    static let hw8 = Homework(name: "DP 개념 공부", due: Date(), isCompleted: false)
+    static let hw9 = Homework(name: "LCD 개념 공부", due: Date(), isCompleted: false)
+    static let hw10 = Homework(name: "GCD 개념 공부", due: Date(), isCompleted: false)
 }

--- a/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
+++ b/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
@@ -206,11 +206,3 @@ struct StudyRoomViewControllerPreview: PreviewProvider {
     }
 
 }
-
-class HomeworkListTitleView: UICollectionReusableView {
-    
-}
-
-class HomeworkListCell: UICollectionViewCell {
-    
-}

--- a/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
+++ b/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
@@ -135,9 +135,9 @@ extension StudyRoomViewController {
 extension StudyRoomViewController: UICollectionViewDelegate {
     
     private func createHomeworkListViewLayout() -> UICollectionViewLayout {
-        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(40))
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(1))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
-        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(1))
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(44))
         let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
         let section = NSCollectionLayoutSection(group: group)
         let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(50))
@@ -158,19 +158,23 @@ extension StudyRoomViewController: UICollectionViewDelegate {
         collectionView = UICollectionView(frame: .zero, collectionViewLayout: createHomeworkListViewLayout())
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         collectionView.delegate = self
+        collectionView.showsVerticalScrollIndicator = false
+        collectionView.layer.borderWidth = 0.5
+        collectionView.layer.borderColor = UIColor.gray.cgColor
+        collectionView.layer.cornerRadius = 15
         view.addSubview(collectionView)
         
         NSLayoutConstraint.activate([
-            collectionView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            collectionView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            collectionView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: margin),
+            collectionView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -margin),
             collectionView.topAnchor.constraint(equalTo: codeCopyButton.bottomAnchor, constant: margin),
-            collectionView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+            collectionView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -margin)
         ])
     }
     
     private func configureDatasource() {
         let cellRegisteration = UICollectionView.CellRegistration<HomeworkListCell, Homework> { cell, indexPath, item in
-            //
+            cell.configureContent(item: item, index: indexPath.row)
         }
         
         datasource = Datasource(collectionView: collectionView, cellProvider: { collectionView, indexPath, item in
@@ -178,9 +182,7 @@ extension StudyRoomViewController: UICollectionViewDelegate {
         })
         
         let headerRegisteration = UICollectionView.SupplementaryRegistration
-        <HomeworkListTitleView>(elementKind: sectionHeaderElementKind) { supplementaryView, elementKind, indexPath in
-            //
-        }
+        <HomeworkListTitleView>(elementKind: sectionHeaderElementKind) { _, _, _ in }
         
         datasource.supplementaryViewProvider = { _, _, index in
             return self.collectionView.dequeueConfiguredReusableSupplementary(using: headerRegisteration, for: index)
@@ -189,7 +191,7 @@ extension StudyRoomViewController: UICollectionViewDelegate {
     
     private func applySnapShot() {
         snapshot.appendSections([.main])
-        snapshot.appendItems(HomeworkMockData.list, toSection: .main)
+        snapshot.appendItems(HomeworkMockData.longList, toSection: .main)
         datasource.apply(snapshot)
     }
     

--- a/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
+++ b/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
@@ -139,16 +139,17 @@ extension StudyRoomViewController {
 extension StudyRoomViewController: UICollectionViewDelegate {
     
     private func createHomeworkListViewLayout() -> UICollectionViewLayout {
-        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(1))
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(40))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(1))
         let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
         let section = NSCollectionLayoutSection(group: group)
-        let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(40))
+        let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(50))
         let sectionHeader = NSCollectionLayoutBoundarySupplementaryItem(
             layoutSize: headerSize,
             elementKind: sectionHeaderElementKind,
             alignment: .top)
+        sectionHeader.pinToVisibleBounds = true
         section.boundarySupplementaryItems = [sectionHeader]
         
         let layout = UICollectionViewCompositionalLayout(section: section)
@@ -161,7 +162,6 @@ extension StudyRoomViewController: UICollectionViewDelegate {
         collectionView = UICollectionView(frame: .zero, collectionViewLayout: createHomeworkListViewLayout())
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         collectionView.delegate = self
-        collectionView.backgroundColor = .red
         view.addSubview(collectionView)
         
         NSLayoutConstraint.activate([
@@ -193,7 +193,7 @@ extension StudyRoomViewController: UICollectionViewDelegate {
     
     private func applySnapShot() {
         snapshot.appendSections([.main])
-        snapshot.appendItems([Homework()], toSection: .main)
+        snapshot.appendItems([Homework(), Homework(), Homework()], toSection: .main)
         datasource.apply(snapshot)
     }
     

--- a/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
+++ b/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
@@ -5,6 +5,7 @@
 //  Created by kelly on 2022/07/18.
 //
 
+import SwiftUI
 import UIKit
 
 class StudyRoomViewController: UIViewController {
@@ -105,4 +106,12 @@ class StudyRoomViewController: UIViewController {
         title = "Swift Study"
         navigationItem.rightBarButtonItem = navigationBarRightItem
     }
+}
+
+struct StudyRoomViewControllerPreview: PreviewProvider {
+    
+    static var previews: some View {
+        StudyRoomViewController().toPreview()
+    }
+
 }

--- a/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
+++ b/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
@@ -47,13 +47,39 @@ class StudyRoomViewController: UIViewController {
         button.addAction(action, for: .touchUpInside)
         return button
     }()
+    
+    // MARK: - HomeworkList property
+    
+    private let sectionHeaderElementKind = "section-header-element-kind"
+    
+    enum HomeworkSection {
+        case main
+    }
+    
+    struct Homework: Hashable {
+        let id = UUID()
+    }
+
+    typealias Datasource = UICollectionViewDiffableDataSource<HomeworkSection, Homework>
+    typealias Snapshot = NSDiffableDataSourceSnapshot<HomeworkSection, Homework>
+    
+    private var collectionView: UICollectionView!
+    private var datasource: Datasource!
+    private var snapshot = Snapshot()
+    
+}
 
     // MARK: - life cycle
 
+extension StudyRoomViewController {
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         configUI()
         render()
+        configureHierachy()
+        configureDatasource()
+        applySnapShot()
     }
 
     private func configUI() {
@@ -108,10 +134,83 @@ class StudyRoomViewController: UIViewController {
     }
 }
 
+// MARK: - Homework List View
+
+extension StudyRoomViewController: UICollectionViewDelegate {
+    
+    private func createHomeworkListViewLayout() -> UICollectionViewLayout {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(1))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(1))
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
+        let section = NSCollectionLayoutSection(group: group)
+        let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(40))
+        let sectionHeader = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: headerSize,
+            elementKind: sectionHeaderElementKind,
+            alignment: .top)
+        section.boundarySupplementaryItems = [sectionHeader]
+        
+        let layout = UICollectionViewCompositionalLayout(section: section)
+        
+        return layout
+    }
+    
+    private func configureHierachy() {
+        let margin: CGFloat = 20
+        collectionView = UICollectionView(frame: .zero, collectionViewLayout: createHomeworkListViewLayout())
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        collectionView.delegate = self
+        collectionView.backgroundColor = .red
+        view.addSubview(collectionView)
+        
+        NSLayoutConstraint.activate([
+            collectionView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            collectionView.topAnchor.constraint(equalTo: codeCopyButton.bottomAnchor, constant: margin),
+            collectionView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+    }
+    
+    private func configureDatasource() {
+        let cellRegisteration = UICollectionView.CellRegistration<HomeworkListCell, Homework> { cell, indexPath, item in
+            //
+        }
+        
+        datasource = Datasource(collectionView: collectionView, cellProvider: { collectionView, indexPath, item in
+            collectionView.dequeueConfiguredReusableCell(using: cellRegisteration, for: indexPath, item: item)
+        })
+        
+        let headerRegisteration = UICollectionView.SupplementaryRegistration
+        <HomeworkListTitleView>(elementKind: sectionHeaderElementKind) { supplementaryView, elementKind, indexPath in
+            //
+        }
+        
+        datasource.supplementaryViewProvider = { _, _, index in
+            return self.collectionView.dequeueConfiguredReusableSupplementary(using: headerRegisteration, for: index)
+        }
+    }
+    
+    private func applySnapShot() {
+        snapshot.appendSections([.main])
+        snapshot.appendItems([Homework()], toSection: .main)
+        datasource.apply(snapshot)
+    }
+    
+}
+
 struct StudyRoomViewControllerPreview: PreviewProvider {
     
     static var previews: some View {
         StudyRoomViewController().toPreview()
     }
 
+}
+
+class HomeworkListTitleView: UICollectionReusableView {
+    
+}
+
+class HomeworkListCell: UICollectionViewCell {
+    
 }

--- a/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
+++ b/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
@@ -55,10 +55,6 @@ class StudyRoomViewController: UIViewController {
     enum HomeworkSection {
         case main
     }
-    
-    struct Homework: Hashable {
-        let id = UUID()
-    }
 
     typealias Datasource = UICollectionViewDiffableDataSource<HomeworkSection, Homework>
     typealias Snapshot = NSDiffableDataSourceSnapshot<HomeworkSection, Homework>
@@ -193,7 +189,7 @@ extension StudyRoomViewController: UICollectionViewDelegate {
     
     private func applySnapShot() {
         snapshot.appendSections([.main])
-        snapshot.appendItems([Homework(), Homework(), Homework()], toSection: .main)
+        snapshot.appendItems(HomeworkMockData.list, toSection: .main)
         datasource.apply(snapshot)
     }
     

--- a/Hatnya/Screens/StudyRoom/UIComponent/HomeworkListCell.swift
+++ b/Hatnya/Screens/StudyRoom/UIComponent/HomeworkListCell.swift
@@ -32,7 +32,7 @@ class HomeworkListCell: UICollectionViewCell {
         return $0
     }(UIView())
     
-    var isComplished = false
+    private var isHomeworkComplished = false
     private let tagSize: CGFloat = 24
     
     override init(frame: CGRect) {
@@ -56,7 +56,7 @@ extension HomeworkListCell {
         let checkedImage = UIImage(systemName: "checkmark.square.fill")
         let emptyImage = UIImage(systemName: "square")
         
-        if isComplished {
+        if isHomeworkComplished {
             checkButton.setImage(emptyImage, for: .normal)
             textLabel.textColor = .label
         } else {
@@ -64,8 +64,8 @@ extension HomeworkListCell {
             textLabel.textColor = .gray
         }
         
-        isComplished.toggle()
-        textLabel.strikeThrough(isComplished)
+        isHomeworkComplished.toggle()
+        textLabel.strikeThrough(isHomeworkComplished)
     }
     
     private func configureSubviews() {

--- a/Hatnya/Screens/StudyRoom/UIComponent/HomeworkListCell.swift
+++ b/Hatnya/Screens/StudyRoom/UIComponent/HomeworkListCell.swift
@@ -71,8 +71,11 @@ extension HomeworkListCell {
     private func configureSubviews() {
         let margin: CGFloat = 20
 
-        addSubview(checkButton)
-        checkButton.translatesAutoresizingMaskIntoConstraints = false
+        [checkButton, tagView, textLabel].forEach { component in
+            addSubview(component)
+            component.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
         NSLayoutConstraint.activate([
             checkButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: margin),
             checkButton.centerYAnchor.constraint(equalTo: centerYAnchor),
@@ -80,8 +83,6 @@ extension HomeworkListCell {
             checkButton.heightAnchor.constraint(greaterThanOrEqualToConstant: margin)
         ])
         
-        addSubview(tagView)
-        tagView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             tagView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -margin),
             tagView.centerYAnchor.constraint(equalTo: centerYAnchor),
@@ -89,13 +90,10 @@ extension HomeworkListCell {
             tagView.heightAnchor.constraint(equalToConstant: tagSize)
         ])
         
-        addSubview(textLabel)
-        textLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             textLabel.leadingAnchor.constraint(equalTo: checkButton.trailingAnchor, constant: margin),
             textLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
             textLabel.trailingAnchor.constraint(equalTo: tagView.leadingAnchor, constant: -margin),
-            textLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: margin),
             textLabel.heightAnchor.constraint(greaterThanOrEqualToConstant: margin)
         ])
         

--- a/Hatnya/Screens/StudyRoom/UIComponent/HomeworkListCell.swift
+++ b/Hatnya/Screens/StudyRoom/UIComponent/HomeworkListCell.swift
@@ -13,6 +13,7 @@ class HomeworkListCell: UICollectionViewCell {
     private lazy var checkButton: UIButton = {
         let emptyCheckImage = UIImage(systemName: "square")
         $0.setImage(emptyCheckImage, for: .normal)
+        $0.setPreferredSymbolConfiguration(.init(pointSize: 25), forImageIn: .normal)
         $0.tintColor = .gray
         $0.addTarget(self, action: #selector(checkButtonTouched), for: .touchUpInside)
         return $0
@@ -20,6 +21,7 @@ class HomeworkListCell: UICollectionViewCell {
     
     private lazy var textLabel: UILabel = {
         $0.text = "알고리즘 1091번"
+        $0.font = .systemFont(ofSize: 19)
         return $0
     }(UILabel())
     
@@ -31,7 +33,7 @@ class HomeworkListCell: UICollectionViewCell {
     }(UIView())
     
     var isComplished = false
-    private let tagSize: CGFloat = 20
+    private let tagSize: CGFloat = 24
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -46,37 +48,6 @@ class HomeworkListCell: UICollectionViewCell {
 }
 
 extension HomeworkListCell {
-    
-    private func configureSubviews() {
-        let margin: CGFloat = 15
-        
-        addSubview(checkButton)
-        checkButton.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            checkButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: margin),
-            checkButton.centerYAnchor.constraint(equalTo: centerYAnchor),
-            checkButton.widthAnchor.constraint(greaterThanOrEqualToConstant: margin),
-            checkButton.heightAnchor.constraint(greaterThanOrEqualToConstant: margin)
-        ])
-        
-        addSubview(textLabel)
-        textLabel.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            textLabel.leadingAnchor.constraint(equalTo: checkButton.trailingAnchor, constant: margin),
-            textLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
-            textLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: margin),
-            textLabel.heightAnchor.constraint(greaterThanOrEqualToConstant: margin)
-        ])
-        
-        addSubview(tagView)
-        tagView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            tagView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -margin),
-            tagView.centerYAnchor.constraint(equalTo: centerYAnchor),
-            tagView.widthAnchor.constraint(equalToConstant: tagSize),
-            tagView.heightAnchor.constraint(equalToConstant: tagSize)
-        ])
-    }
     
     @objc
     func checkButtonTouched() {
@@ -94,12 +65,80 @@ extension HomeworkListCell {
         isComplished.toggle()
     }
     
+    private func configureSubviews() {
+        let margin: CGFloat = 20
+
+        addSubview(checkButton)
+        checkButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            checkButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: margin),
+            checkButton.centerYAnchor.constraint(equalTo: centerYAnchor),
+            checkButton.widthAnchor.constraint(equalToConstant: 30),
+            checkButton.heightAnchor.constraint(greaterThanOrEqualToConstant: margin)
+        ])
+        
+        addSubview(tagView)
+        tagView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            tagView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -margin),
+            tagView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            tagView.widthAnchor.constraint(equalToConstant: tagSize),
+            tagView.heightAnchor.constraint(equalToConstant: tagSize)
+        ])
+        
+        addSubview(textLabel)
+        textLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            textLabel.leadingAnchor.constraint(equalTo: checkButton.trailingAnchor, constant: margin),
+            textLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+            textLabel.trailingAnchor.constraint(equalTo: tagView.leadingAnchor, constant: -margin),
+            textLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: margin),
+            textLabel.heightAnchor.constraint(greaterThanOrEqualToConstant: margin)
+        ])
+        
+    }
+    
+    func configureContent(item: Homework, index: Int) {
+        textLabel.text = item.name
+        tagView.backgroundColor = TagColor.order(index: index)
+    }
+    
 }
 
 struct HomeworkListCellPreview: PreviewProvider {
     
     static var previews: some View {
         HomeworkListCell().toPreview()
+    }
+
+}
+
+enum TagColor: Int, CaseIterable {
+    case pink
+    case yellow
+    case green
+    case lightBlue
+    case purple
+    
+    static func color(_ tagColor: TagColor) -> UIColor {
+        switch tagColor {
+        case .pink:
+            return .tagPink
+        case .yellow:
+            return .tagYellow
+        case .green:
+            return .tagGreen
+        case .lightBlue:
+            return .tagLightBlue
+        case .purple:
+            return .tagPurple
+        }
+    }
+    
+    static func order(index: Int) -> UIColor {
+        let colorNum = index % Self.allCases.count
+        let orderColor = TagColor(rawValue: colorNum) ?? .pink
+        return Self.color(orderColor)
     }
 
 }

--- a/Hatnya/Screens/StudyRoom/UIComponent/HomeworkListCell.swift
+++ b/Hatnya/Screens/StudyRoom/UIComponent/HomeworkListCell.swift
@@ -47,6 +47,8 @@ class HomeworkListCell: UICollectionViewCell {
     
 }
 
+// MARK: - UI method
+
 extension HomeworkListCell {
     
     @objc
@@ -109,36 +111,6 @@ struct HomeworkListCellPreview: PreviewProvider {
     
     static var previews: some View {
         HomeworkListCell().toPreview()
-    }
-
-}
-
-enum TagColor: Int, CaseIterable {
-    case pink
-    case yellow
-    case green
-    case lightBlue
-    case purple
-    
-    static func color(_ tagColor: TagColor) -> UIColor {
-        switch tagColor {
-        case .pink:
-            return .tagPink
-        case .yellow:
-            return .tagYellow
-        case .green:
-            return .tagGreen
-        case .lightBlue:
-            return .tagLightBlue
-        case .purple:
-            return .tagPurple
-        }
-    }
-    
-    static func order(index: Int) -> UIColor {
-        let colorNum = index % Self.allCases.count
-        let orderColor = TagColor(rawValue: colorNum) ?? .pink
-        return Self.color(orderColor)
     }
 
 }

--- a/Hatnya/Screens/StudyRoom/UIComponent/HomeworkListCell.swift
+++ b/Hatnya/Screens/StudyRoom/UIComponent/HomeworkListCell.swift
@@ -10,12 +10,88 @@ import UIKit
 
 class HomeworkListCell: UICollectionViewCell {
     
+    private lazy var checkButton: UIButton = {
+        let emptyCheckImage = UIImage(systemName: "square")
+        $0.setImage(emptyCheckImage, for: .normal)
+        $0.tintColor = .gray
+        $0.addTarget(self, action: #selector(checkButtonTouched), for: .touchUpInside)
+        return $0
+    }(UIButton())
+    
+    private lazy var textLabel: UILabel = {
+        $0.text = "알고리즘 1091번"
+        return $0
+    }(UILabel())
+    
+    private lazy var tagView: UIView = {
+        $0.backgroundColor = .blue
+        $0.frame.size = CGSize(width: self.tagSize, height: self.tagSize)
+        $0.layer.cornerRadius = $0.frame.size.width / 2
+        return $0
+    }(UIView())
+    
+    var isComplished = false
+    private let tagSize: CGFloat = 20
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
+        configureSubviews()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+        configureSubviews()
+    }
+    
+}
+
+extension HomeworkListCell {
+    
+    private func configureSubviews() {
+        let margin: CGFloat = 15
+        
+        addSubview(checkButton)
+        checkButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            checkButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: margin),
+            checkButton.centerYAnchor.constraint(equalTo: centerYAnchor),
+            checkButton.widthAnchor.constraint(greaterThanOrEqualToConstant: margin),
+            checkButton.heightAnchor.constraint(greaterThanOrEqualToConstant: margin)
+        ])
+        
+        addSubview(textLabel)
+        textLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            textLabel.leadingAnchor.constraint(equalTo: checkButton.trailingAnchor, constant: margin),
+            textLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+            textLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: margin),
+            textLabel.heightAnchor.constraint(greaterThanOrEqualToConstant: margin)
+        ])
+        
+        addSubview(tagView)
+        tagView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            tagView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -margin),
+            tagView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            tagView.widthAnchor.constraint(equalToConstant: tagSize),
+            tagView.heightAnchor.constraint(equalToConstant: tagSize)
+        ])
+    }
+    
+    @objc
+    func checkButtonTouched() {
+        let checkedImage = UIImage(systemName: "checkmark.square.fill")
+        let emptyImage = UIImage(systemName: "square")
+        
+        if isComplished {
+            checkButton.setImage(emptyImage, for: .normal)
+            textLabel.textColor = .label
+        } else {
+            checkButton.setImage(checkedImage, for: .normal)
+            textLabel.textColor = .gray
+        }
+        
+        isComplished.toggle()
     }
     
 }

--- a/Hatnya/Screens/StudyRoom/UIComponent/HomeworkListCell.swift
+++ b/Hatnya/Screens/StudyRoom/UIComponent/HomeworkListCell.swift
@@ -1,0 +1,29 @@
+//
+//  HomeworkListCell.swift
+//  Hatnya
+//
+//  Created by 리아 on 2022/07/20.
+//
+
+import SwiftUI
+import UIKit
+
+class HomeworkListCell: UICollectionViewCell {
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+}
+
+struct HomeworkListCellPreview: PreviewProvider {
+    
+    static var previews: some View {
+        HomeworkListCell().toPreview()
+    }
+
+}

--- a/Hatnya/Screens/StudyRoom/UIComponent/HomeworkListCell.swift
+++ b/Hatnya/Screens/StudyRoom/UIComponent/HomeworkListCell.swift
@@ -65,6 +65,7 @@ extension HomeworkListCell {
         }
         
         isComplished.toggle()
+        textLabel.strikeThrough(isComplished)
     }
     
     private func configureSubviews() {

--- a/Hatnya/Screens/StudyRoom/UIComponent/HomeworkListTitleView.swift
+++ b/Hatnya/Screens/StudyRoom/UIComponent/HomeworkListTitleView.swift
@@ -25,11 +25,13 @@ class HomeworkListTitleView: UICollectionReusableView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         configureSubviews()
+        backgroundColor = .systemBackground
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         configureSubviews()
+        backgroundColor = .systemBackground
     }
     
 }

--- a/Hatnya/Screens/StudyRoom/UIComponent/HomeworkListTitleView.swift
+++ b/Hatnya/Screens/StudyRoom/UIComponent/HomeworkListTitleView.swift
@@ -1,0 +1,29 @@
+//
+//  HomeworkListTitleView.swift
+//  Hatnya
+//
+//  Created by 리아 on 2022/07/20.
+//
+
+import SwiftUI
+import UIKit
+
+class HomeworkListTitleView: UICollectionReusableView {
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+}
+
+struct HomeworkListTitlePreview: PreviewProvider {
+    
+    static var previews: some View {
+        HomeworkListTitleView().toPreview()
+    }
+
+}

--- a/Hatnya/Screens/StudyRoom/UIComponent/HomeworkListTitleView.swift
+++ b/Hatnya/Screens/StudyRoom/UIComponent/HomeworkListTitleView.swift
@@ -10,14 +10,53 @@ import UIKit
 
 class HomeworkListTitleView: UICollectionReusableView {
     
+    private lazy var titleLabel: UILabel = {
+        $0.text = "숙제 목록"
+        $0.textColor = .gray
+        return $0
+    }(UILabel())
+    
+    private lazy var plusButton: UIButton = {
+        let plusImage = UIImage(systemName: "plus")
+        $0.setImage(plusImage, for: .normal)
+        return $0
+    }(UIButton())
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
+        configureSubviews()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+        configureSubviews()
     }
     
+}
+
+extension HomeworkListTitleView {
+    
+    private func configureSubviews() {
+        let margin: CGFloat = 15
+        
+        addSubview(titleLabel)
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: margin),
+            titleLabel.topAnchor.constraint(equalTo: topAnchor, constant: margin),
+            titleLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: margin),
+            titleLabel.heightAnchor.constraint(greaterThanOrEqualToConstant: margin)
+        ])
+        
+        addSubview(plusButton)
+        plusButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            plusButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -margin),
+            plusButton.topAnchor.constraint(equalTo: topAnchor, constant: margin),
+            plusButton.widthAnchor.constraint(greaterThanOrEqualToConstant: margin),
+            plusButton.heightAnchor.constraint(greaterThanOrEqualToConstant: margin)
+        ])
+    }
 }
 
 struct HomeworkListTitlePreview: PreviewProvider {


### PR DESCRIPTION

## 작업내용
- [x] DiffableDataSource를 활용한 테이블뷰 레이아웃 그리기
- [x] 테이블뷰 셀 그리기
- [x] 섹션 뷰 그리기
- [x] 숙제별 태그 색 돌아가면서 배정하기
- [x] 목데이터 만들고 연결하기

<image src ="https://user-images.githubusercontent.com/73650994/180115627-28fe3fad-1a1c-4b19-8ba2-7ee4a5118328.png" width="300">

## 리뷰포인트
- a479e0b2666e769b8d04c67dcce9f70f16b15489 
  - 숙제 태그 색이 순서에 따라 배정되는 것을 enum과 내부 메서드로 구현했습니다
  - 익스텐션도 아니고 리터럴도 아니라서 어느 폴더의 하위 항목으로 넣을 지 고민하다가, `Global/Utility` 라는 폴더를 새로 만들게 되었습니다

## 질문
- 현재 단계에서 (숙제 목록-모두의 숙제 현황)간 데이터 연결 작업을 고려해야할까요?

## 다음으로 진행될 작업
- `+` 버튼을 눌렀을 때의 숙제 수정 화면

# 참고한 코드 출처
- [UIButton의 이미지 크기 조절하기](https://gyuios.tistory.com/26)
- [UILabel에서 취소선 토글하기](https://stackoverflow.com/questions/13133014/how-can-i-create-a-uilabel-with-strikethrough-text)