### PR TITLE
[FEAT] 숙제 목록 편집 화면

### DIFF
--- a/Hatnya.xcodeproj/project.pbxproj
+++ b/Hatnya.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		AED2E1B928880EDC00B32FF7 /* Homework.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED2E1B828880EDC00B32FF7 /* Homework.swift */; };
 		AED2E1BC2888DE6E00B32FF7 /* TagColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED2E1BB2888DE6E00B32FF7 /* TagColor.swift */; };
 		AED2E1BE2888DF2D00B32FF7 /* UILabel+StrikeThrough.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED2E1BD2888DF2D00B32FF7 /* UILabel+StrikeThrough.swift */; };
+		AED2E1C0288C3A3700B32FF7 /* EditTaskSupplementaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED2E1BF288C3A3700B32FF7 /* EditTaskSupplementaryView.swift */; };
+		AED2E1C2288C3A6000B32FF7 /* EditTaskTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED2E1C1288C3A6000B32FF7 /* EditTaskTableViewCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -60,6 +62,8 @@
 		AED2E1B828880EDC00B32FF7 /* Homework.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Homework.swift; sourceTree = "<group>"; };
 		AED2E1BB2888DE6E00B32FF7 /* TagColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagColor.swift; sourceTree = "<group>"; };
 		AED2E1BD2888DF2D00B32FF7 /* UILabel+StrikeThrough.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+StrikeThrough.swift"; sourceTree = "<group>"; };
+		AED2E1BF288C3A3700B32FF7 /* EditTaskSupplementaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTaskSupplementaryView.swift; sourceTree = "<group>"; };
+		AED2E1C1288C3A6000B32FF7 /* EditTaskTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTaskTableViewCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -209,6 +213,7 @@
 		A28DEF92288551BF004014DE /* EditTask */ = {
 			isa = PBXGroup;
 			children = (
+				AED2E1C3288C3BC600B32FF7 /* UIComponent */,
 				A28DEF9628855228004014DE /* EditTaskViewController.swift */,
 			);
 			path = EditTask;
@@ -247,6 +252,15 @@
 				AED2E1BB2888DE6E00B32FF7 /* TagColor.swift */,
 			);
 			path = Utility;
+			sourceTree = "<group>";
+		};
+		AED2E1C3288C3BC600B32FF7 /* UIComponent */ = {
+			isa = PBXGroup;
+			children = (
+				AED2E1C1288C3A6000B32FF7 /* EditTaskTableViewCell.swift */,
+				AED2E1BF288C3A3700B32FF7 /* EditTaskSupplementaryView.swift */,
+			);
+			path = UIComponent;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -343,6 +357,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				39F3F8E62886778900256D56 /* StudyChartView.swift in Sources */,
+				AED2E1C0288C3A3700B32FF7 /* EditTaskSupplementaryView.swift in Sources */,
 				3982366D2886EF0400F6B004 /* ColorLiteral.swift in Sources */,
 				A28DEF9D28855285004014DE /* JoinStudyViewController.swift in Sources */,
 				AED2E1B72887B4DF00B32FF7 /* HomeworkListCell.swift in Sources */,
@@ -357,6 +372,7 @@
 				AED2E1B928880EDC00B32FF7 /* Homework.swift in Sources */,
 				A28DEFA1288552CC004014DE /* StudyGroup.swift in Sources */,
 				AED2E1BC2888DE6E00B32FF7 /* TagColor.swift in Sources */,
+				AED2E1C2288C3A6000B32FF7 /* EditTaskTableViewCell.swift in Sources */,
 				AED2E1B52887B4C700B32FF7 /* HomeworkListTitleView.swift in Sources */,
 				A28DEF9728855228004014DE /* EditTaskViewController.swift in Sources */,
 				A28DEF9528855209004014DE /* CreateStudyViewController.swift in Sources */,

--- a/Hatnya/Screens/EditTask/EditTaskViewController.swift
+++ b/Hatnya/Screens/EditTask/EditTaskViewController.swift
@@ -18,6 +18,7 @@ class EditTaskViewController: UIViewController {
         super.viewDidLoad()
         configureLayout()
         configureDatasource()
+        tableView.isEditing = true
         applySnapshot()
     }
     
@@ -29,10 +30,36 @@ private enum EditTaskSection {
 
 private class EditTaskDatasource: UITableViewDiffableDataSource<EditTaskSection, Homework> {
     
+    override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+        return true
+    }
+    
+    override func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
+        guard let sourceIdentifier = itemIdentifier(for: sourceIndexPath) else { return }
+        guard let destinationIdentifier = itemIdentifier(for: destinationIndexPath) else { return }
+        guard sourceIndexPath != destinationIndexPath else { return }
+        
+        var snapshot = snapshot()
+        
+        if let sourceIndex = snapshot.indexOfItem(sourceIdentifier),
+           let destinationIndex = snapshot.indexOfItem(destinationIdentifier) {
+            snapshot.deleteItems([sourceIdentifier])
+            let isAfter = destinationIndex > sourceIndex
+            
+            if isAfter {
+                snapshot.insertItems([sourceIdentifier], afterItem: destinationIdentifier)
+            } else {
+                snapshot.insertItems([sourceIdentifier], beforeItem: destinationIdentifier)
+            }
+        }
+        
+        apply(snapshot, animatingDifferences: true)
+    }
+    
 }
 
 extension EditTaskViewController {
-    
+
     private func configureLayout() {
         tableView = UITableView(frame: .zero, style: .plain)
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: UITableViewCell.description())
@@ -59,7 +86,7 @@ extension EditTaskViewController {
     
     private func applySnapshot() {
         snapshot.appendSections([.main])
-        snapshot.appendItems(HomeworkMockData.longList, toSection: .main)
+        snapshot.appendItems(HomeworkMockData.list, toSection: .main)
         taskDataSource.apply(snapshot)
     }
     

--- a/Hatnya/Screens/EditTask/EditTaskViewController.swift
+++ b/Hatnya/Screens/EditTask/EditTaskViewController.swift
@@ -26,6 +26,8 @@ final class EditTaskViewController: UIViewController {
     
 }
 
+// MARK: - Configure TableView
+
 extension EditTaskViewController {
 
     private func configureLayout() {
@@ -63,6 +65,8 @@ extension EditTaskViewController {
     }
     
 }
+
+// MARK: - Edit TableView
 
 extension EditTaskViewController: UITableViewDelegate {
         

--- a/Hatnya/Screens/EditTask/EditTaskViewController.swift
+++ b/Hatnya/Screens/EditTask/EditTaskViewController.swift
@@ -112,33 +112,7 @@ private enum EditTaskSection {
 }
 
 private class EditTaskDatasource: UITableViewDiffableDataSource<EditTaskSection, Homework> {
-    
-    override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
-        return true
-    }
-    
-    override func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
-        guard let sourceIdentifier = itemIdentifier(for: sourceIndexPath) else { return }
-        guard let destinationIdentifier = itemIdentifier(for: destinationIndexPath) else { return }
-        guard sourceIndexPath != destinationIndexPath else { return }
-        
-        var snapshot = snapshot()
-        
-        if let sourceIndex = snapshot.indexOfItem(sourceIdentifier),
-           let destinationIndex = snapshot.indexOfItem(destinationIdentifier) {
-            snapshot.deleteItems([sourceIdentifier])
-            let isAfter = destinationIndex > sourceIndex
-            
-            if isAfter {
-                snapshot.insertItems([sourceIdentifier], afterItem: destinationIdentifier)
-            } else {
-                snapshot.insertItems([sourceIdentifier], beforeItem: destinationIdentifier)
-            }
-        }
-        
-        apply(snapshot, animatingDifferences: true)
-    }
-    
+
     override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
         return true
     }

--- a/Hatnya/Screens/EditTask/EditTaskViewController.swift
+++ b/Hatnya/Screens/EditTask/EditTaskViewController.swift
@@ -2,9 +2,10 @@
 //  EditTaskViewController.swift
 //  Hatnya
 //
-//  Created by kelly on 2022/07/18.
+//  Created by 리아 on 2022/07/21.
 //
 
+import SwiftUI
 import UIKit
 
 class EditTaskViewController: UIViewController {
@@ -13,4 +14,12 @@ class EditTaskViewController: UIViewController {
         super.viewDidLoad()
     }
     
+}
+
+struct EditTaskPreview: PreviewProvider {
+    
+    static var previews: some View {
+        EditTaskViewController().toPreview()
+    }
+
 }

--- a/Hatnya/Screens/EditTask/EditTaskViewController.swift
+++ b/Hatnya/Screens/EditTask/EditTaskViewController.swift
@@ -9,9 +9,58 @@ import SwiftUI
 import UIKit
 
 class EditTaskViewController: UIViewController {
-
+    
+    private var taskDataSource: UITableViewDiffableDataSource<EditTaskSection, Homework>!
+    private var snapshot = NSDiffableDataSourceSnapshot<EditTaskSection, Homework>()
+    private var tableView: UITableView!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureLayout()
+        configureDatasource()
+        applySnapshot()
+    }
+    
+}
+
+private enum EditTaskSection {
+    case main
+}
+
+private class EditTaskDatasource: UITableViewDiffableDataSource<EditTaskSection, Homework> {
+    
+}
+
+extension EditTaskViewController {
+    
+    private func configureLayout() {
+        tableView = UITableView(frame: .zero, style: .plain)
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: UITableViewCell.description())
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(tableView)
+        
+        NSLayoutConstraint.activate([
+            tableView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+    }
+    
+    private func configureDatasource() {
+        taskDataSource = EditTaskDatasource(tableView: tableView, cellProvider: { tableView, indexPath, task in
+            let cell = tableView.dequeueReusableCell(withIdentifier: UITableViewCell.description(), for: indexPath)
+            var content = cell.defaultContentConfiguration()
+            content.text = task.name
+            cell.contentConfiguration = content
+            return cell
+        })
+    }
+    
+    private func applySnapshot() {
+        snapshot.appendSections([.main])
+        snapshot.appendItems(HomeworkMockData.longList, toSection: .main)
+        taskDataSource.apply(snapshot)
     }
     
 }

--- a/Hatnya/Screens/EditTask/EditTaskViewController.swift
+++ b/Hatnya/Screens/EditTask/EditTaskViewController.swift
@@ -19,9 +19,29 @@ final class EditTaskViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureNavi()
         configureLayout()
         configureDatasource()
         applySnapshot()
+    }
+    
+}
+
+// MARK: - Configure Navigation
+
+extension EditTaskViewController {
+    
+    private func configureNavi() {
+
+        self.navigationController?.navigationBar.backgroundColor = .systemBackground
+        self.navigationItem.title = "숙제 목록"
+        let completeButton = UIBarButtonItem(title: "완료", style: .plain, target: self, action: #selector(completeButtonTouched))
+        self.navigationItem.rightBarButtonItem = completeButton
+    }
+    
+    @objc
+    func completeButtonTouched() {
+        dismiss(animated: true)
     }
     
 }

--- a/Hatnya/Screens/EditTask/EditTaskViewController.swift
+++ b/Hatnya/Screens/EditTask/EditTaskViewController.swift
@@ -32,7 +32,6 @@ final class EditTaskViewController: UIViewController {
 extension EditTaskViewController {
     
     private func configureNavi() {
-
         self.navigationController?.navigationBar.backgroundColor = .systemBackground
         self.navigationItem.title = "숙제 목록"
         let completeButton = UIBarButtonItem(title: "완료", style: .plain, target: self, action: #selector(completeButtonTouched))

--- a/Hatnya/Screens/EditTask/UIComponent/EditTaskSupplementaryView.swift
+++ b/Hatnya/Screens/EditTask/UIComponent/EditTaskSupplementaryView.swift
@@ -46,34 +46,27 @@ final class EditTaskSupplementaryView: UITableViewHeaderFooterView {
 extension EditTaskSupplementaryView {
     
     private func configureHierachy() {
-        plusButton.translatesAutoresizingMaskIntoConstraints = false
-        contentView.addSubview(plusButton)
+        [plusButton, textField, borderView].forEach { component in
+            component.translatesAutoresizingMaskIntoConstraints = false
+            contentView.addSubview(component)
+        }
+
         NSLayoutConstraint.activate([
             plusButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             plusButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 17),
             plusButton.widthAnchor.constraint(equalToConstant: 30),
-            plusButton.heightAnchor.constraint(greaterThanOrEqualToConstant: 30)
-        ])
-        
-        textField.translatesAutoresizingMaskIntoConstraints = false
-        contentView.addSubview(textField)
-        NSLayoutConstraint.activate([
+            plusButton.heightAnchor.constraint(greaterThanOrEqualToConstant: 30),
+
             textField.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             textField.leadingAnchor.constraint(equalTo: plusButton.trailingAnchor, constant: 10),
             textField.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -10),
-            textField.heightAnchor.constraint(greaterThanOrEqualToConstant: 50)
-        ])
-        
-        borderView.translatesAutoresizingMaskIntoConstraints = false
-        contentView.addSubview(borderView)
-        NSLayoutConstraint.activate([
+            textField.heightAnchor.constraint(greaterThanOrEqualToConstant: 50),
+
             borderView.centerYAnchor.constraint(equalTo: contentView.bottomAnchor),
             borderView.heightAnchor.constraint(equalToConstant: 0.5),
             borderView.leadingAnchor.constraint(equalTo: plusButton.leadingAnchor, constant: 5),
-            borderView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
-        ])
-        
-        NSLayoutConstraint.activate([
+            borderView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+
             contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 48)
         ])
     }

--- a/Hatnya/Screens/EditTask/UIComponent/EditTaskSupplementaryView.swift
+++ b/Hatnya/Screens/EditTask/UIComponent/EditTaskSupplementaryView.swift
@@ -1,0 +1,96 @@
+//
+//  EditTaskSupplementaryView.swift
+//  Hatnya
+//
+//  Created by 리아 on 2022/07/23.
+//
+
+import SwiftUI
+import UIKit
+
+final class EditTaskSupplementaryView: UITableViewHeaderFooterView {
+    
+    private lazy var plusButton: UIButton = {
+        var config = UIImage.SymbolConfiguration(paletteColors: [.systemGreen])
+        config = config.applying(UIImage.SymbolConfiguration(scale: .large))
+        let plusImage = UIImage(systemName: "plus.circle.fill", withConfiguration: config)
+        $0.setImage(plusImage, for: .normal)
+        $0.addTarget(self, action: #selector(plusButtonTouched), for: .touchUpInside)
+        return $0
+    }(UIButton())
+    
+    private var textField = UITextField()
+    
+    private lazy var borderView: UIView = {
+        $0.backgroundColor = .secondarySystemFill
+        return $0
+    }(UIView())
+    
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+        configureHierachy()
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configureHierachy()
+        configureUI()
+    }
+    
+}
+
+extension EditTaskSupplementaryView {
+    
+    private func configureHierachy() {
+        plusButton.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(plusButton)
+        NSLayoutConstraint.activate([
+            plusButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            plusButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 17),
+            plusButton.widthAnchor.constraint(equalToConstant: 30),
+            plusButton.heightAnchor.constraint(greaterThanOrEqualToConstant: 30)
+        ])
+        
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(textField)
+        NSLayoutConstraint.activate([
+            textField.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            textField.leadingAnchor.constraint(equalTo: plusButton.trailingAnchor, constant: 10),
+            textField.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -10),
+            textField.heightAnchor.constraint(greaterThanOrEqualToConstant: 50)
+        ])
+        
+        borderView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(borderView)
+        NSLayoutConstraint.activate([
+            borderView.centerYAnchor.constraint(equalTo: contentView.bottomAnchor),
+            borderView.heightAnchor.constraint(equalToConstant: 0.5),
+            borderView.leadingAnchor.constraint(equalTo: plusButton.leadingAnchor, constant: 5),
+            borderView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
+        ])
+        
+        NSLayoutConstraint.activate([
+            contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 48)
+        ])
+    }
+    
+    private func configureUI() {
+        textField.placeholder = "새로운 항목 추가"
+    }
+    
+    @objc
+    func plusButtonTouched() {
+        print(textField.text!)
+        textField.text = ""
+    }
+    
+}
+
+struct EditTaskSupplementaryPreview: PreviewProvider {
+    
+    static var previews: some View {
+        EditTaskSupplementaryView().toPreview()
+    }
+    
+}

--- a/Hatnya/Screens/EditTask/UIComponent/EditTaskSupplementaryView.swift
+++ b/Hatnya/Screens/EditTask/UIComponent/EditTaskSupplementaryView.swift
@@ -5,10 +5,13 @@
 //  Created by 리아 on 2022/07/23.
 //
 
+import Combine
 import SwiftUI
 import UIKit
 
 final class EditTaskSupplementaryView: UITableViewHeaderFooterView {
+    
+    @Published var newTask = Homework(name: "", due: Date(), isCompleted: false)
     
     private lazy var plusButton: UIButton = {
         var config = UIImage.SymbolConfiguration(paletteColors: [.systemGreen])
@@ -81,7 +84,8 @@ extension EditTaskSupplementaryView {
     
     @objc
     func plusButtonTouched() {
-        print(textField.text!)
+        guard let text = textField.text else { return }
+        newTask = Homework(name: text, due: Date(), isCompleted: false)
         textField.text = ""
     }
     

--- a/Hatnya/Screens/EditTask/UIComponent/EditTaskTableViewCell.swift
+++ b/Hatnya/Screens/EditTask/UIComponent/EditTaskTableViewCell.swift
@@ -1,0 +1,47 @@
+//
+//  EditTaskTableViewCell.swift
+//  Hatnya
+//
+//  Created by 리아 on 2022/07/23.
+//
+
+import UIKit
+
+final class EditTaskTableViewCell: UITableViewCell {
+    
+    var textField = UITextField()
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        configureViewHierachy()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configureViewHierachy()
+    }
+    
+}
+
+extension EditTaskTableViewCell: UITextFieldDelegate {
+    
+    func configureViewHierachy() {
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        textField.delegate = self
+        contentView.addSubview(textField)
+        
+        let margin: CGFloat = 13
+        NSLayoutConstraint.activate([
+            textField.leadingAnchor.constraint(equalTo: contentView.safeAreaLayoutGuide.leadingAnchor, constant: margin),
+            textField.topAnchor.constraint(equalTo: contentView.safeAreaLayoutGuide.topAnchor, constant: margin),
+            textField.trailingAnchor.constraint(equalTo: contentView.safeAreaLayoutGuide.trailingAnchor, constant: -margin),
+            textField.bottomAnchor.constraint(equalTo: contentView.safeAreaLayoutGuide.bottomAnchor, constant: -margin)
+        ])
+    }
+    
+    func setText(with text: String) {
+        textField.text = text
+        
+    }
+    
+}

--- a/Hatnya/Screens/EditTask/UIComponent/EditTaskTableViewCell.swift
+++ b/Hatnya/Screens/EditTask/UIComponent/EditTaskTableViewCell.swift
@@ -9,7 +9,7 @@ import UIKit
 
 final class EditTaskTableViewCell: UITableViewCell {
     
-    var textField = UITextField()
+    private var textField = UITextField()
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -23,11 +23,10 @@ final class EditTaskTableViewCell: UITableViewCell {
     
 }
 
-extension EditTaskTableViewCell: UITextFieldDelegate {
+extension EditTaskTableViewCell {
     
-    func configureViewHierachy() {
+    private func configureViewHierachy() {
         textField.translatesAutoresizingMaskIntoConstraints = false
-        textField.delegate = self
         contentView.addSubview(textField)
         
         let margin: CGFloat = 13
@@ -41,7 +40,6 @@ extension EditTaskTableViewCell: UITextFieldDelegate {
     
     func setText(with text: String) {
         textField.text = text
-        
     }
     
 }

--- a/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
+++ b/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
@@ -132,8 +132,14 @@ extension StudyRoomViewController {
 
 // MARK: - Homework List View
 
-extension StudyRoomViewController: UICollectionViewDelegate {
-    
+extension StudyRoomViewController: UICollectionViewDelegate, EditDelegate {
+
+    func editButtonTapped() {
+        let newViewController = UINavigationController(rootViewController: EditTaskViewController())
+        present(newViewController, animated: true)
+//        self.navigationController?.pushViewController(newViewController, animated: true)
+    }
+
     private func createHomeworkListViewLayout() -> UICollectionViewLayout {
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(1))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
@@ -182,7 +188,9 @@ extension StudyRoomViewController: UICollectionViewDelegate {
         })
         
         let headerRegisteration = UICollectionView.SupplementaryRegistration
-        <HomeworkListTitleView>(elementKind: sectionHeaderElementKind) { _, _, _ in }
+        <HomeworkListTitleView>(elementKind: sectionHeaderElementKind) { supplymentaryView, _, _ in
+            supplymentaryView.delegate = self
+        }
         
         datasource.supplementaryViewProvider = { _, _, index in
             return self.collectionView.dequeueConfiguredReusableSupplementary(using: headerRegisteration, for: index)

--- a/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
+++ b/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
@@ -137,7 +137,6 @@ extension StudyRoomViewController: UICollectionViewDelegate, EditDelegate {
     func editButtonTapped() {
         let newViewController = UINavigationController(rootViewController: EditTaskViewController())
         present(newViewController, animated: true)
-//        self.navigationController?.pushViewController(newViewController, animated: true)
     }
 
     private func createHomeworkListViewLayout() -> UICollectionViewLayout {

--- a/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
+++ b/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import UIKit
 
-class StudyRoomViewController: UIViewController {
+final class StudyRoomViewController: UIViewController {
 
     // MARK: - property
 

--- a/Hatnya/Screens/StudyRoom/UIComponent/HomeworkListCell.swift
+++ b/Hatnya/Screens/StudyRoom/UIComponent/HomeworkListCell.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import UIKit
 
-class HomeworkListCell: UICollectionViewCell {
+final class HomeworkListCell: UICollectionViewCell {
     
     private lazy var checkButton: UIButton = {
         let emptyCheckImage = UIImage(systemName: "square")

--- a/Hatnya/Screens/StudyRoom/UIComponent/HomeworkListTitleView.swift
+++ b/Hatnya/Screens/StudyRoom/UIComponent/HomeworkListTitleView.swift
@@ -8,7 +8,9 @@
 import SwiftUI
 import UIKit
 
-class HomeworkListTitleView: UICollectionReusableView {
+final class HomeworkListTitleView: UICollectionReusableView {
+    
+    weak var delegate: EditDelegate?
     
     private lazy var titleLabel: UILabel = {
         $0.text = "숙제 목록"
@@ -19,6 +21,7 @@ class HomeworkListTitleView: UICollectionReusableView {
     private lazy var plusButton: UIButton = {
         let plusImage = UIImage(systemName: "plus")
         $0.setImage(plusImage, for: .normal)
+        $0.addTarget(self, action: #selector(plusButtonTouched), for: .touchUpInside)
         return $0
     }(UIButton())
     
@@ -59,6 +62,13 @@ extension HomeworkListTitleView {
             plusButton.heightAnchor.constraint(greaterThanOrEqualToConstant: margin)
         ])
     }
+    
+    @objc
+    func plusButtonTouched() {
+        delegate?.editButtonTapped()
+        
+    }
+    
 }
 
 struct HomeworkListTitlePreview: PreviewProvider {
@@ -67,4 +77,8 @@ struct HomeworkListTitlePreview: PreviewProvider {
         HomeworkListTitleView().toPreview()
     }
 
+}
+
+protocol EditDelegate: AnyObject {
+    func editButtonTapped()
 }

--- a/Hatnya/Screens/StudyRoom/UIComponent/HomeworkListTitleView.swift
+++ b/Hatnya/Screens/StudyRoom/UIComponent/HomeworkListTitleView.swift
@@ -66,7 +66,6 @@ extension HomeworkListTitleView {
     @objc
     func plusButtonTouched() {
         delegate?.editButtonTapped()
-        
     }
     
 }


### PR DESCRIPTION
## 작업내용
- [x] 테이블 뷰 레이아웃
- [x] 테이블 뷰 셀 편집 모드
- [x] 숙제 추가 기능
- [x] + 버튼 누르면 모달 띄우기
- [x] 완료 누르면 모달 해제

<img src ="https://user-images.githubusercontent.com/73650994/180742139-33751384-5967-4c3e-93d3-5b2ec09728c1.gif" width="200">


## 리뷰포인트
- 새로운 숙제 추가 부분
  - `tableView delegate`로는 셀 추가 시 바로 반영이 되지 않아 푸터 뷰로 해결하였습니다.
  - 대신에 뷰 간 데이터 이동을 combine을 사용하여 했습니다.
- 뷰 전환 부분
  - StudyRoomViewController 에서 EditTaskViewController로 넘어가기 위한 버튼이 서브뷰 안에 있어 델리게이트로 처리했습니다.

## 다음으로 진행될 작업
 - 파이어베이스 연결

## 참고한 코드 출처
- Modern Collection View