### PR TITLE
[FEAT] calculate deadline

### DIFF
--- a/Hatnya.xcodeproj/project.pbxproj
+++ b/Hatnya.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		A28DEF9F28855299004014DE /* StudyListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28DEF9E28855299004014DE /* StudyListViewController.swift */; };
 		A28DEFA528855325004014DE /* ImageLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28DEFA428855325004014DE /* ImageLiteral.swift */; };
 		A28DEFA828855354004014DE /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28DEFA728855354004014DE /* UIColor+Extension.swift */; };
+		A2A1FD842897C38E00EC765F /* DeadlineManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2A1FD832897C38E00EC765F /* DeadlineManager.swift */; };
 		A7D2316F288D93C700A59A85 /* StudyListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7D2316E288D93C700A59A85 /* StudyListTableViewCell.swift */; };
 		A7D23171288D93DE00A59A85 /* StudyGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7D23170288D93DE00A59A85 /* StudyGroup.swift */; };
 		A7D23173288D93EF00A59A85 /* StudyList.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A7D23172288D93EF00A59A85 /* StudyList.storyboard */; };
@@ -85,6 +86,7 @@
 		A28DEF9E28855299004014DE /* StudyListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyListViewController.swift; sourceTree = "<group>"; };
 		A28DEFA428855325004014DE /* ImageLiteral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLiteral.swift; sourceTree = "<group>"; };
 		A28DEFA728855354004014DE /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
+		A2A1FD832897C38E00EC765F /* DeadlineManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeadlineManager.swift; sourceTree = "<group>"; };
 		A7D2316E288D93C700A59A85 /* StudyListTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StudyListTableViewCell.swift; sourceTree = "<group>"; };
 		A7D23170288D93DE00A59A85 /* StudyGroup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StudyGroup.swift; sourceTree = "<group>"; };
 		A7D23172288D93EF00A59A85 /* StudyList.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = StudyList.storyboard; sourceTree = "<group>"; };
@@ -268,6 +270,7 @@
 				39823674288F715800F6B004 /* Cell */,
 				39F3F8E42886777600256D56 /* UIComponent */,
 				A28DEF9828855239004014DE /* StudyRoomViewController.swift */,
+				A2A1FD832897C38E00EC765F /* DeadlineManager.swift */,
 			);
 			path = StudyRoom;
 			sourceTree = "<group>";
@@ -459,6 +462,7 @@
 				A7D23171288D93DE00A59A85 /* StudyGroup.swift in Sources */,
 				AED2E1B928880EDC00B32FF7 /* Homework.swift in Sources */,
 				AED2E1BC2888DE6E00B32FF7 /* TagColor.swift in Sources */,
+				A2A1FD842897C38E00EC765F /* DeadlineManager.swift in Sources */,
 				AED2E1C2288C3A6000B32FF7 /* EditTaskTableViewCell.swift in Sources */,
 				AED2E1B52887B4C700B32FF7 /* HomeworkListTitleView.swift in Sources */,
 				39823676288F718900F6B004 /* StudyChartCollectionViewCell.swift in Sources */,

--- a/Hatnya/Global/Extension/Date+Extension.swift
+++ b/Hatnya/Global/Extension/Date+Extension.swift
@@ -16,8 +16,8 @@ extension Date {
     }
     
     var toString: String {
-        let dataFormatter = DateFormatter()
-        dataFormatter.dateFormat = "YYYY.MM.dd"
-        return dataFormatter.string(from: self)
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "YYYY.MM.dd"
+        return dateFormatter.string(from: self)
     }
 }

--- a/Hatnya/Global/Extension/Date+Extension.swift
+++ b/Hatnya/Global/Extension/Date+Extension.swift
@@ -14,4 +14,10 @@ extension Date {
         formatter.locale = Locale(identifier: "ko_KR")
         return formatter.string(from: self)
     }
+    
+    var toString: String {
+        let dataFormatter = DateFormatter()
+        dataFormatter.dateFormat = "YYYY.MM.dd"
+        return dataFormatter.string(from: self)
+    }
 }

--- a/Hatnya/Screens/StudyRoom/DeadlineManager.swift
+++ b/Hatnya/Screens/StudyRoom/DeadlineManager.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class DeadlineManager {
+final class DeadlineManager {
     let dayOfWeekNum = ["월": 0, "화": 1, "수": 2, "목": 3, "금": 4, "토": 5, "일": 6]
     
     func getOffsetToDeadline(appStartDate: Date, cycle: Int, cycleDay: [String]) -> Int {

--- a/Hatnya/Screens/StudyRoom/DeadlineManager.swift
+++ b/Hatnya/Screens/StudyRoom/DeadlineManager.swift
@@ -1,0 +1,61 @@
+//
+//  DeadlineManager.swift
+//  Hatnya
+//
+//  Created by kelly on 2022/08/01.
+//
+
+import Foundation
+
+class DeadlineManager {
+    let dayOfWeekNum = ["월": 0, "화": 1, "수": 2, "목": 3, "금": 4, "토": 5, "일": 6]
+    
+    func getOffsetToDeadline(appStartDate: Date, cycle: Int, cycleDay: [String]) -> Int {
+        let studyStartDate = getStudyStartDate(appStartDate: appStartDate, cycleDay: cycleDay)
+        var offsetToDeadline: Int = 0
+        
+        if studyStartDate < Date() {
+            offsetToDeadline = getClosestCycleOffset(cycle: cycleDay, startDay: Date())
+            let nearestCycleDate = Date(timeIntervalSinceNow: 60 * 60 * 24 * Double(offsetToDeadline))
+            
+            let dateComponent = Calendar.current.dateComponents([.day], from: studyStartDate, to: nearestCycleDate)
+            guard let offsetDay = dateComponent.day else { return 0 }
+            let offsetWeek = offsetDay / 7
+            
+            if !offsetWeek.isMultiple(of: cycle) {
+                offsetToDeadline += 7 * (cycle - (offsetWeek % cycle))
+            }
+            offsetToDeadline -= (dayOfWeekNum[nearestCycleDate.getDayOfWeek]! - dayOfWeekNum[cycleDay[0]]!)
+        } else {
+            let dateComponent = Calendar.current.dateComponents([.day], from: Date(), to: studyStartDate)
+            guard let offset = dateComponent.day else { return 0 }
+            offsetToDeadline = offset
+        }
+        
+        return offsetToDeadline
+    }
+
+    private func getStudyStartDate(appStartDate: Date, cycleDay: [String]) -> Date {
+        let offset = getClosestCycleOffset(cycle: [cycleDay[0]], startDay: appStartDate)
+        let studyStartDate = Date(timeInterval: 60 * 60 * 24 * Double(offset), since: appStartDate)
+        
+        return studyStartDate
+    }
+
+    private func getClosestCycleOffset(cycle: [String], startDay: Date) -> Int {
+        let startDayOfWeek = startDay.getDayOfWeek
+        var offset = -1
+        
+        for day in cycle {
+            if dayOfWeekNum[day]! >= dayOfWeekNum[startDayOfWeek]! {
+                offset = dayOfWeekNum[day]! - dayOfWeekNum[startDayOfWeek]!
+                break
+            }
+        }
+        if offset == -1 {
+            offset = 7 - (dayOfWeekNum[startDayOfWeek]! - dayOfWeekNum[cycle[0]]!)
+        }
+        
+        return offset
+    }
+}

--- a/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
+++ b/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
@@ -223,11 +223,8 @@ extension StudyRoomViewController {
             offsetToDeadline = offset
         }
         let deadlineDate = Date(timeInterval: 60 * 60 * 24 * Double(offsetToDeadline), since: Date())
-        let dataFormatter = DateFormatter()
-        dataFormatter.dateFormat = "YYYY.MM.dd"
-        let deadLineString = dataFormatter.string(from: deadlineDate)
         dDayLabel.text = "D-\(offsetToDeadline)"
-        deadLineLabel.text = "\(deadLineString)(\(setDayOfWeek(deadLineString.stringToDate))) 까지"
+        deadLineLabel.text = "\(deadlineDate.toString)(\(setDayOfWeek(deadlineDate))) 까지"
     }
 
     private func getStudyStartDate() -> Date {

--- a/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
+++ b/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
@@ -14,7 +14,7 @@ final class StudyRoomViewController: UIViewController {
     let cycle = 2
     let cycleDay = ["수", "일"]
     let appStartDate = Date(timeIntervalSinceNow: 0)
-    let dayOfWeekNum = ["월" : 0, "화" : 1, "수" : 2, "목" : 3, "금" : 4, "토" : 5, "일" : 6]
+    let dayOfWeekNum = ["월": 0, "화": 1, "수": 2, "목": 3, "금": 4, "토": 5, "일": 6]
     
     private enum Menu {
         case inviteTeam
@@ -203,19 +203,29 @@ extension StudyRoomViewController {
         guard let date = day else { return "" }
         return date.getDayOfWeek
     }
-    
+
     private func getStudyStartDate() -> Date {
-        let firstDayofCycle = cycleDay[0]
-        let appStartDayOfWeek = appStartDate.getDayOfWeek
-        var offset: Int = dayOfWeekNum[appStartDayOfWeek]! - dayOfWeekNum[firstDayofCycle]!
-        if offset > 0 {
-            offset = 7 - offset
-        } else {
-            offset *= -1
-        }
-        let studyStartDate = Date(timeInterval: 60 * 60 * 24 * Double(offset), since: appStartDate)
+        let offset = getClosestCycleOffset(cycle: [cycleDay[0]], startDay: appStartDate)
+        let stusyStartDate = Date(timeInterval: 60 * 60 * 24 * Double(offset), since: appStartDate)
         
-        return studyStartDate
+        return stusyStartDate
+    }
+
+    private func getClosestCycleOffset(cycle: [String], startDay: Date) -> Int {
+        let startDayOfWeek = startDay.getDayOfWeek
+        var offset = -1
+        
+        for day in cycle {
+            if dayOfWeekNum[day]! >= dayOfWeekNum[startDayOfWeek]! {
+                offset = dayOfWeekNum[day]! - dayOfWeekNum[startDayOfWeek]!
+                break
+            }
+        }
+        if offset == -1 {
+            offset = 7 - (dayOfWeekNum[startDayOfWeek]! - dayOfWeekNum[cycle[0]]!)
+        }
+        
+        return offset
     }
 
     private func setupNavigationRightButton() -> UIMenu {

--- a/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
+++ b/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
@@ -11,6 +11,10 @@ import UIKit
 final class StudyRoomViewController: UIViewController {
     var deadLineString = "2022.08.01"
     var oneDayTimeInterval: Double = 86_400
+    let cycle = 2
+    let cycleDay = ["수", "일"]
+    let appStartDate = Date(timeIntervalSinceNow: 0)
+    let dayOfWeekNum = ["월" : 0, "화" : 1, "수" : 2, "목" : 3, "금" : 4, "토" : 5, "일" : 6]
     
     private enum Menu {
         case inviteTeam
@@ -198,6 +202,20 @@ extension StudyRoomViewController {
     private func setDayOfWeek(_ day: Date?) -> String {
         guard let date = day else { return "" }
         return date.getDayOfWeek
+    }
+    
+    private func getStudyStartDate() -> Date {
+        let firstDayofCycle = cycleDay[0]
+        let appStartDayOfWeek = appStartDate.getDayOfWeek
+        var offset: Int = dayOfWeekNum[appStartDayOfWeek]! - dayOfWeekNum[firstDayofCycle]!
+        if offset > 0 {
+            offset = 7 - offset
+        } else {
+            offset *= -1
+        }
+        let studyStartDate = Date(timeInterval: 60 * 60 * 24 * Double(offset), since: appStartDate)
+        
+        return studyStartDate
     }
 
     private func setupNavigationRightButton() -> UIMenu {

--- a/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
+++ b/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
@@ -79,14 +79,12 @@ final class StudyRoomViewController: UIViewController {
     }()
     private lazy var deadLineLabel: UILabel = {
         let label = UILabel()
-        label.text = "\(deadLineString)(\(setDayOfWeek(deadLineString.stringToDate))) 까지"
         label.textColor = .grey001
         label.font = UIFont.systemFont(ofSize: 14)
         return label
     }()
     private lazy var dDayLabel: UILabel = {
         let label = UILabel()
-        label.text = "D-\(getDateDifference())"
         label.font = UIFont.boldSystemFont(ofSize: 34)
         return label
     }()
@@ -141,6 +139,7 @@ extension StudyRoomViewController {
     private func configUI() {
         view.backgroundColor = .backgroundGrey
         setupNavigationBar()
+        setDeadline()
     }
 
     private func render() {
@@ -202,6 +201,33 @@ extension StudyRoomViewController {
     private func setDayOfWeek(_ day: Date?) -> String {
         guard let date = day else { return "" }
         return date.getDayOfWeek
+    }
+    
+    private func setDeadline() {
+        let appStartDate = getStudyStartDate()
+        var offsetToDeadline: Int = 0
+        
+        if appStartDate < Date() {
+            let dateComponent = Calendar.current.dateComponents([.day], from: appStartDate, to: Date())
+            guard let offsetDay = dateComponent.day else { return }
+            let offsetWeek = offsetDay % 7
+            
+            offsetToDeadline = getClosestCycleOffset(cycle: cycleDay, startDay: Date())
+            
+            if offsetWeek.isMultiple(of: cycle) {
+                offsetToDeadline += 7 * (offsetWeek % cycle)
+            }
+        } else {
+            let dateComponent = Calendar.current.dateComponents([.day], from: Date(), to: appStartDate)
+            guard let offset = dateComponent.day else { return }
+            offsetToDeadline = offset
+        }
+        let deadlineDate = Date(timeInterval: 60 * 60 * 24 * Double(offsetToDeadline), since: Date())
+        let dataFormatter = DateFormatter()
+        dataFormatter.dateFormat = "YYYY.MM.dd"
+        let deadLineString = dataFormatter.string(from: deadlineDate)
+        dDayLabel.text = "D-\(offsetToDeadline)"
+        deadLineLabel.text = "\(deadLineString)(\(setDayOfWeek(deadLineString.stringToDate))) 까지"
     }
 
     private func getStudyStartDate() -> Date {

--- a/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
+++ b/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
@@ -9,8 +9,6 @@ import SwiftUI
 import UIKit
 
 final class StudyRoomViewController: UIViewController {
-//    var deadLineString = "2022.08.01"
-//    var oneDayTimeInterval: Double = 86_400
     let cycle = 3
     let cycleDay = ["수", "일"]
     let appStartDate = Date(timeIntervalSinceNow: (60 * 60 * 24 * 10 * -1))
@@ -190,14 +188,6 @@ extension StudyRoomViewController {
         title = "Swift Study"
         navigationItem.rightBarButtonItem = navigationBarRightItem
     }
-
-//    private func getDateDifference() -> Int {
-//        guard let date = deadLineString.stringToDate else { return 0 }
-//        let distance = date.distance(to: Date())
-//        let resultToDouble = Double(distance) / oneDayTimeInterval
-//        let result = abs(Int(resultToDouble))
-//        return result
-//    }
 
     private func setDayOfWeek(_ day: Date?) -> String {
         guard let date = day else { return "" }

--- a/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
+++ b/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
@@ -12,7 +12,6 @@ final class StudyRoomViewController: UIViewController {
     let cycle = 3
     let cycleDay = ["수", "일"]
     let appStartDate = Date(timeIntervalSinceNow: (60 * 60 * 24 * 10 * -1))
-    let dayOfWeekNum = ["월": 0, "화": 1, "수": 2, "목": 3, "금": 4, "토": 5, "일": 6]
     
     private enum Menu {
         case inviteTeam
@@ -194,54 +193,11 @@ extension StudyRoomViewController {
     }
     
     private func setDeadlineLabels() {
-        let studyStartDate = getStudyStartDate()
-        var offsetToDeadline: Int = 0
-        
-        if studyStartDate < Date() {
-            offsetToDeadline = getClosestCycleOffset(cycle: cycleDay, startDay: Date())
-            let nearestCycleDate = Date(timeIntervalSinceNow: 60 * 60 * 24 * Double(offsetToDeadline))
-            
-            let dateComponent = Calendar.current.dateComponents([.day], from: studyStartDate, to: nearestCycleDate)
-            guard let offsetDay = dateComponent.day else { return }
-            let offsetWeek = offsetDay / 7
-            
-            if !offsetWeek.isMultiple(of: cycle) {
-                offsetToDeadline += 7 * (cycle - (offsetWeek % cycle))
-            }
-            offsetToDeadline -= (dayOfWeekNum[nearestCycleDate.getDayOfWeek]! - dayOfWeekNum[cycleDay[0]]!)
-        } else {
-            let dateComponent = Calendar.current.dateComponents([.day], from: Date(), to: studyStartDate)
-            guard let offset = dateComponent.day else { return }
-            offsetToDeadline = offset
-        }
-        
+        let deadlineManager = DeadlineManager()
+        let offsetToDeadline = deadlineManager.getOffsetToDeadline(appStartDate: appStartDate, cycle: cycle, cycleDay: cycleDay)
         let deadlineDate = Date(timeInterval: 60 * 60 * 24 * Double(offsetToDeadline), since: Date())
         dDayLabel.text = "D-\(offsetToDeadline)"
         deadLineLabel.text = "\(deadlineDate.toString)(\(setDayOfWeek(deadlineDate))) 까지"
-    }
-
-    private func getStudyStartDate() -> Date {
-        let offset = getClosestCycleOffset(cycle: [cycleDay[0]], startDay: appStartDate)
-        let studyStartDate = Date(timeInterval: 60 * 60 * 24 * Double(offset), since: appStartDate)
-        
-        return studyStartDate
-    }
-
-    private func getClosestCycleOffset(cycle: [String], startDay: Date) -> Int {
-        let startDayOfWeek = startDay.getDayOfWeek
-        var offset = -1
-        
-        for day in cycle {
-            if dayOfWeekNum[day]! >= dayOfWeekNum[startDayOfWeek]! {
-                offset = dayOfWeekNum[day]! - dayOfWeekNum[startDayOfWeek]!
-                break
-            }
-        }
-        if offset == -1 {
-            offset = 7 - (dayOfWeekNum[startDayOfWeek]! - dayOfWeekNum[cycle[0]]!)
-        }
-        
-        return offset
     }
 
     private func setupNavigationRightButton() -> UIMenu {

--- a/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
+++ b/Hatnya/Screens/StudyRoom/StudyRoomViewController.swift
@@ -138,7 +138,6 @@ extension StudyRoomViewController {
         view.backgroundColor = .backgroundGrey
         setupNavigationBar()
         setDeadlineLabels()
-        print("app ---- ", appStartDate)
     }
 
     private func render() {
@@ -207,9 +206,7 @@ extension StudyRoomViewController {
             let offsetWeek = offsetDay / 7
             
             if !offsetWeek.isMultiple(of: cycle) {
-                print("not fit", offsetWeek % cycle)
                 offsetToDeadline += 7 * (cycle - (offsetWeek % cycle))
-                print("not fittt", offsetToDeadline)
             }
             offsetToDeadline -= (dayOfWeekNum[nearestCycleDate.getDayOfWeek]! - dayOfWeekNum[cycleDay[0]]!)
         } else {


### PR DESCRIPTION
## 작업내용
- [x] 스터디의 주기와 시작일을 기반으로 디데이를 계산하는 로직 작성

<img width="266" alt="스크린샷 2022-07-31 오후 7 40 22" src="https://user-images.githubusercontent.com/80809782/182022326-5e64573d-4ead-47af-8d43-fbb7cd8e1617.png">


## 리뷰포인트
setDeadline이 configUI 성격이랑 맞을까요?
다른 분들이 스터디룸뷰에 파베에 저장된 데이터를 불러오는 작업을 하는거 같아 저도 따로 불러오지 않고 머지 후에 연결하려고 아직 연결은 안했습니다!

## 다음으로 진행될 작업
파베에서 불러온 정보 사용
